### PR TITLE
Expanding documentation for nix shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ Our documentation provides answers to the questions you might have If you have q
 
 On the Where's (for now): 
 
-* We only support Ubuntu 20.4
+* We only support up to Ubuntu 20.4
 * We only support Intel x86 Architectures with the correct collection of instructions (check our [installation guide](installation/installation-guide.md)).
 On the How's we have included:
 
 * A **new [installation guide](installation/installation-guide.md)** that includes instructions for an automatized install, manual install, and nix support execution. 
-* If you are not a read the docs kinda person, don't you worry, we gotcha! We provided you with a script that automatize the installation. Just run `installation/setup-project.sh` and it will quickly install and set the project up (It will also use the Default Example 3 from [Auto-Test-Data](Auto-Test-Data/), including setting up your Certificates). More details can be found, on the link above. 
+* If you are not a read the docs kinda person, don't you worry, we gotcha! We provided you with a script that automatize the installation. Just run `installation/setup-project.sh` and it will quickly install and set the project up (It will also use the Default Example 1 from [Auto-Test-Data](Auto-Test-Data/), including setting up your Certificates). More details can be found, on the link above. 
 
 We support DB's now. Hence, we have added a **new configuration file** to the Data folder: The Storage config file. We have added them to all the [Auto-Test-Data](Auto-Test-Data/) example setups, persisting information on files.
 

--- a/README.md
+++ b/README.md
@@ -74,18 +74,20 @@ Besides what you can find above, the framework is complemented by following cont
 If you are interested on only one of the aspects above, we do not mind you citing that work instead.
 
 ## The How's (Before You Start):
-We describe here the new functionality and behaviours. If you have questions about legacy code, you can check the **SCALE-MAMBA official documentation**.
+Our documentation provides answers to the questions you might have If you have questions about legacy code, you can check the **SCALE-MAMBA official documentation**.
 
+On the Where's (for now): 
+
+* We only support Ubuntu 20.4
+* We only support Intel x86 Architectures with the correct collection of instructions (check our [installation guide](installation/installation-guide.md)).
 On the How's we have included:
 
-* A **new [installation guide](installation/installation-guide.md)**. 
-* A script that automatize the installation. Just run `installation/setup-project.sh` and it will quickly install and set the project up (It will also use the Default Example 3 from [Auto-Test-Data](Auto-Test-Data/), including setting up your Certificates). 
-* For an easy deployment, we have updated the [shell.nix](shell.nix) with our new dependencies. 
-
+* A **new [installation guide](installation/installation-guide.md)** that includes instructions for an automatized install, manual install, and nix support execution. 
+* If you are not a read the docs kinda person, don't you worry, we gotcha! We provided you with a script that automatize the installation. Just run `installation/setup-project.sh` and it will quickly install and set the project up (It will also use the Default Example 3 from [Auto-Test-Data](Auto-Test-Data/), including setting up your Certificates). More details can be found, on the link above. 
 
 We support DB's now. Hence, we have added a **new configuration file** to the Data folder: The Storage config file. We have added them to all the [Auto-Test-Data](Auto-Test-Data/) example setups, persisting information on files.
 
-Learn more about storage config files [here](MD-Files/storage-config-file.md).  
+Learn more about storage config files [here](MD-Files/storage-config-file.md). 
 
 ### Setting up your own MySQL
 We use `MySql` as the default DB Engine. Our architecture is flexible enough to allow you incorporate different engines. They are used by the Input/Output database system and the Offline Garbling feature. At the moment however we only support `MySql`. 

--- a/installation/installation-guide.md
+++ b/installation/installation-guide.md
@@ -298,20 +298,55 @@ If you want to use this approach, install `nix-shell` if you haven't already
 
 (you may need a re-login to update the environment variables).
 
+We suggest you to follow these steps:
+
+### Install `nix-shell`:
+
+First, download and install nix:
 ```
 curl -L https://nixos.org/nix/install | sh
 ```
 
-Invoke `nix-shell` to get a fully ready development environment with all libraries installed. This will automatically
-download all the dependencies and tools you need. As in `SCALE-MAMBA` the only thing you need to do is to:
-
-- Create a `CONFIG.mine`. 
-
-- Erase the `OSSL` variable and set `ROOT = ..`.
-
-After you have compiled the system, and setup your Secret Sharing scheme, you can compile a program in
-the `Programs` directory by invoking:
+Once the installation is finished, please enable nix to your shell:
 
 ```
+. ~/.nix-profile/etc/profile.d/nix.sh
+```
+
+You can make these changes permanent by adding nix to your `.bashrc`:
+```
+echo ". ~/.nix-profile/etc/profile.d/nix.sh" >> ~/.bashrc
+```
+
+Finally, don't forget to always source your `/.bashrc`:
+```
+source ~/.bashrc
+```
+### Configuring `FANNG-MPC` in your `nix-shell`: 
+First, invoke `nix-shell` to get a fully ready development environment with all libraries installed via: 
+
+```
+cd <path_to_fanng>/FANNG_MPC
+nix-shell
+```
+Create a `CONFIG.mine`: 
+```
+cp CONFIG CONFIG.mine
+```
+In `CONFIG.mine`, erase the `OSSL` variable and set `ROOT = ..`.
+
+### Running `FANNG-MPC`:
+You have to simply follow __stage 4__ and __stage 5__ as described above. This will allow you to ocmpile `FANNG-MPC` and configure your secret sharing scheme.
+
+After you have finish both, you can now compile and run any program in
+the `Programs` directory by invoking (we use `tutorial` as an example):
+
+```
+cd <path_to_fanng>/FANNG_MPC
 ./compile.sh Programs/tutorial
+./Scripts/run-online.sh Programs/tutorial
 ```
+
+Please note the above needs to be executed from `<path_to_fanng>/FANNG_MPC`.
+
+And that's it! Thanks for using `FANNG-MPC`.

--- a/installation/installation-guide.md
+++ b/installation/installation-guide.md
@@ -291,10 +291,10 @@ These commands copy the necessary configuration files for variant 1 into the app
 
 
 ## Alternative installation using nix-shell
-In the documentation you will see quick install information
+In the documentation, you will see quick install information
 using `nix-shell` for installing the dependencies.
 
-If you want to use this approach, install `nix-shell` if you haven't already
+If you want to use this approach, install `nix-shell` if you haven't done it already.
 
 (you may need a re-login to update the environment variables).
 
@@ -336,9 +336,9 @@ cp CONFIG CONFIG.mine
 In `CONFIG.mine`, erase the `OSSL` variable and set `ROOT = ..`.
 
 ### Running `FANNG-MPC`:
-You have to simply follow __stage 4__ and __stage 5__ as described above. This will allow you to ocmpile `FANNG-MPC` and configure your secret sharing scheme.
+You have to simply follow __[stage 4](#stage-4-final-compilation)__ and __[stage 5](#stage-5-selecting-a-protocol-variant)__ as described above. This will allow you to compile `FANNG-MPC` and configure your secret sharing scheme.
 
-After you have finish both, you can now compile and run any program in
+After you have finished both, you can now compile and run any program in
 the `Programs` directory by invoking (we use `tutorial` as an example):
 
 ```


### PR DESCRIPTION
Detailed Description:
🎨 ✨ 📝  We noticed the installation instructions for nix were confusing, and needed more precise explanations.
Solution:
- We redacted in a different way the nix content on the main readme to reduce the risk of running on misinterpretations.
- We stated clearly we support version 20.04
- We included a detailed guideline for nix installation